### PR TITLE
improve quality of what should I do

### DIFF
--- a/lib/ex_assignment/todos.ex
+++ b/lib/ex_assignment/todos.ex
@@ -48,8 +48,32 @@ defmodule ExAssignment.Todos do
     list_todos(:open)
     |> case do
       [] -> nil
-      todos -> Enum.take_random(todos, 1) |> List.first()
+      todo_list ->
+        sorted_by_probability =
+          todo_list
+          |> calculate_probability()
+          |> List.first()
+
+      Enum.find(todo_list, &(&1.id == sorted_by_probability.id))
     end
+  end
+
+  # Calculate probablities for all todos
+  def calculate_probability(todo_list) do
+    todo_list
+    |> Enum.map(fn todo ->
+      %{id: todo.id, probablity: probability(todo, todo_list)}
+    end)
+  end
+
+  # Count the probability of a todo item
+  def probability(todo, todos) do
+    urgency_score(todo) / Enum.reduce(todos, 0, fn t, acc -> acc + urgency_score(t) end)
+  end
+
+  # Calculate the urgency score of a todo item
+  defp urgency_score(todo) do
+    1 / todo.priority
   end
 
   @doc """

--- a/test/ex_assignment/todos_test.exs
+++ b/test/ex_assignment/todos_test.exs
@@ -1,13 +1,12 @@
 defmodule ExAssignment.TodosTest do
   use ExAssignment.DataCase
 
+  import ExAssignment.TodosFixtures
+
   alias ExAssignment.Todos
+  alias ExAssignment.Todos.Todo
 
   describe "todos" do
-    alias ExAssignment.Todos.Todo
-
-    import ExAssignment.TodosFixtures
-
     @invalid_attrs %{done: nil, priority: nil, title: nil}
 
     test "list_todos/0 returns all todos" do
@@ -59,5 +58,81 @@ defmodule ExAssignment.TodosTest do
       todo = todo_fixture()
       assert %Ecto.Changeset{} = Todos.change_todo(todo)
     end
+  end
+
+  describe "get_recommended/0" do
+    test "returns all open todos" do
+      open_todo = todo_fixture(%{done: false})
+      _done_todo = todo_fixture(%{done: true})
+
+      assert Todos.list_todos(:open) == [open_todo]
+    end
+
+    test "returns all todos with ascending pritority order" do
+      # given
+      open_todo_1 = todo_fixture(%{done: false, priority: 20})
+      open_todo_2 = todo_fixture(%{done: true, priority: 40})
+
+      # when
+      assert Todos.list_todos() == [open_todo_1, open_todo_2]
+    end
+  end
+  describe "probability/2" do
+    test "returns correct probability for Prepare lunch" do
+      # given
+      todos = seed_todo()
+      prepare_lunch = Enum.at(todos, 0)
+
+      # when
+      probability = Todos.probability(prepare_lunch, todos)
+
+      # then
+      assert probability == 0.529891304347826
+    end
+
+    test "returns correct probability for Water flowers" do
+      # given
+      todos = seed_todo()
+      water_flowers = Enum.at(todos, 1)
+
+      # when
+      probability = Todos.probability(water_flowers, todos)
+
+      # then
+      assert probability == 0.21195652173913043
+    end
+
+    test "returns correct probability for Shop groceries" do
+      # given
+      todos = seed_todo()
+      shop_groceries = Enum.at(todos, 2)
+
+      # when
+      probability = Todos.probability(shop_groceries, todos)
+
+      # then
+      assert probability == 0.17663043478260868
+    end
+
+    test "returns correct probability for Buy new flower pots" do
+      # given
+      todos = seed_todo()
+      buy_new_flower_pots = Enum.at(todos, 3)
+
+      # when
+      probability = Todos.probability(buy_new_flower_pots, todos)
+
+      # then
+      assert probability == 0.08152173913043478
+    end
+  end
+
+  defp seed_todo() do
+    todo1 = todo_fixture(%{title: "Prepare lunch", priority: 20})
+    todo2 = todo_fixture(%{title: "Water flowers", priority: 50})
+    todo3 = todo_fixture(%{title: "Shop groceries", priority: 60})
+    todo4 = todo_fixture(%{title: "Buy new flower pots", priority: 130})
+
+    [todo1, todo2, todo3, todo4]
   end
 end


### PR DESCRIPTION
### Solution for exercise 1: Improve the quality of 'What should I do next?' recommendations
When opening http://localhost:4000/todos, the system displays one of the todos at the top, that it recommends to be performed next. Currently this todo is selected randomly from the list of open todos.

We would like to continue displaying a randomly selected todo in this spot, but the todo should be selected in such a way, that todos with a higher urgency also have a higher chance to be recommended.

The probability of a todo to be recommended should correspond to its urgency, when compared to the urgency of other todos.

As an example lets consider there are 4 open todos in the list:

Prepare lunch (priority: 20)
Water flowers (priority: 50)
Shop groceries (priority: 60)
Buy new flower pots (priority: 130)
Note A high urgency is encoded as a lower value in the priority field of a todo. For example a todo with a priority of 20 is considered to be more urgent than a todo with a priority of 50.

The probability for recommending Prepare lunch should be ~2.5 times as high as recommending Water flowers, ~3 times as high as Shop groceries and ~6.5 times as high as recommending Buy new flower pots. All other probabilities should follow the same rule.